### PR TITLE
allow usage without scope

### DIFF
--- a/src/Forms/Components/TailwindColorPicker.php
+++ b/src/Forms/Components/TailwindColorPicker.php
@@ -21,7 +21,7 @@ class TailwindColorPicker extends Field
 
     public $bgColorSelected = '';
 
-    public $scope;
+    public $scope = '';
 
     public $colorsOpacityActivated = false;
 


### PR DESCRIPTION
Fixing prepending "null" when used without scope